### PR TITLE
RAP-3986 Fix createSeries, deleteSeries

### DIFF
--- a/Libs/CodeGen/ApiGen/src/main/resources/api/series.api
+++ b/Libs/CodeGen/ApiGen/src/main/resources/api/series.api
@@ -6,6 +6,10 @@ api(Series) {
    @entitle=/repo/write
    @public void createSeriesRepo(String seriesRepoUri, String config);
    
+   [Creates an empty series.]
+   @entitle=/repo/write
+   @public void createSeries(String seriesUri);
+   
    [Check for the existence of a given repository]
    @entitle=/repo/list
    @public Boolean seriesRepoExists(String seriesRepoUri);

--- a/Libs/RaptureAddinCore/src/main/java/rapture/series/SeriesStore.java
+++ b/Libs/RaptureAddinCore/src/main/java/rapture/series/SeriesStore.java
@@ -104,4 +104,8 @@ public interface SeriesStore {
     void unregisterKey(String key, boolean isFolder);
 
     SeriesValue getLastPoint(String key);
+    
+    void createSeries(String key);
+
+    void deleteSeries(String key);
 }

--- a/Libs/RaptureAddins/Cassandra/src/main/java/rapture/series/cassandra/AstyanaxSeriesConnection.java
+++ b/Libs/RaptureAddins/Cassandra/src/main/java/rapture/series/cassandra/AstyanaxSeriesConnection.java
@@ -215,7 +215,7 @@ public class AstyanaxSeriesConnection extends AstyanaxCassandraBase {
         }
     };
 
-    private void registerKey(String key) {
+    void registerKey(String key) {
         if (DIRECTORY_KEY.equals(key) || ChildKeyUtil.isRowKey(key)) {
             return;
         } else try {

--- a/Libs/RaptureAddins/Cassandra/src/main/java/rapture/series/cassandra/CassandraSeriesStore.java
+++ b/Libs/RaptureAddins/Cassandra/src/main/java/rapture/series/cassandra/CassandraSeriesStore.java
@@ -234,4 +234,15 @@ public class CassandraSeriesStore implements SeriesStore {
         List<SeriesValue> points = getPointsAfterReverse(key, "", 1);
         return points.isEmpty() ? null : points.get(0);
     }
+    
+    @Override
+    public void createSeries(String key) {
+        cass.registerKey(key);
+    }
+    
+    @Override
+    public void deleteSeries(String key) {
+        unregisterKey(key);
+        deletePointsFromSeries(key);
+    }
 }

--- a/Libs/RaptureAddins/MongoDb/src/main/java/rapture/series/mongo/MongoSeriesStore.java
+++ b/Libs/RaptureAddins/MongoDb/src/main/java/rapture/series/mongo/MongoSeriesStore.java
@@ -472,4 +472,15 @@ public class MongoSeriesStore implements SeriesStore {
         };
         return wrapper.doAction();
     }
+    
+	@Override
+	public void createSeries(String key) {
+		registerKey(key);
+	}
+
+	@Override
+	public void deleteSeries(String key) {
+		unregisterKey(key);
+		deletePointsFromSeries(key);
+	}
 }

--- a/Libs/RaptureCore/src/main/java/rapture/kernel/SeriesApiImpl.java
+++ b/Libs/RaptureCore/src/main/java/rapture/kernel/SeriesApiImpl.java
@@ -586,8 +586,8 @@ public class SeriesApiImpl extends KernelBase implements SeriesApi {
             String parentUri = seriesURI.substring(0, lastSlash);
             String name = seriesURI.substring(lastSlash + 1, seriesURI.length());
 
-            log.info("parentUri: " + parentUri);
-            log.info("seriesUri: " + seriesURI);
+            log.debug("parentUri: " + parentUri);
+            log.debug("seriesUri: " + seriesURI);
             for (RaptureFolderInfo folder : listSeriesByUriPrefix(context, parentUri, 1).values()) {
                 if (folder.getName().equals(name)) {
                     return true;
@@ -600,10 +600,16 @@ public class SeriesApiImpl extends KernelBase implements SeriesApi {
         }
     }
 
-    @Override
     public void deleteSeries(CallingContext context, String seriesURI) {
         RaptureURI uri = new RaptureURI(seriesURI, Scheme.SERIES);
         SeriesRepo repository = getRepoOrFail(uri);
-        repository.deletePointsFromSeries(uri.getDocPath());
+        repository.deleteSeries(uri.getDocPath());
+    }
+
+    @Override
+    public void createSeries(CallingContext context, String seriesURI) {
+        RaptureURI uri = new RaptureURI(seriesURI, Scheme.SERIES);
+        SeriesRepo repository = getRepoOrFail(uri);
+        repository.createSeries(uri.getDocPath());
     }
 }

--- a/Libs/RaptureCore/src/main/java/rapture/repo/SeriesRepo.java
+++ b/Libs/RaptureCore/src/main/java/rapture/repo/SeriesRepo.java
@@ -160,4 +160,12 @@ public class SeriesRepo {
     public SeriesValue getLastPoint(String key) {
         return store.getLastPoint(key);
     }
+    
+	public void createSeries(String key) {
+		store.createSeries(key);
+	}
+
+	public void deleteSeries(String key) {
+		store.deleteSeries(key);
+	}
 }

--- a/Libs/RaptureCore/src/main/java/rapture/series/file/FileSeriesStore.java
+++ b/Libs/RaptureCore/src/main/java/rapture/series/file/FileSeriesStore.java
@@ -443,4 +443,15 @@ public class FileSeriesStore implements SeriesStore {
         }
         return null;
     }
+    
+    @Override
+    public void createSeries(String key) {
+        writeSeries(key, new ArrayList<SeriesValue>());
+    }
+
+    @Override
+    public void deleteSeries(String key) {
+        unregisterKey(key);
+        deletePointsFromSeries(key);
+    }
 }

--- a/Libs/RaptureCore/src/main/java/rapture/series/mem/MemorySeriesStore.java
+++ b/Libs/RaptureCore/src/main/java/rapture/series/mem/MemorySeriesStore.java
@@ -298,4 +298,16 @@ public class MemorySeriesStore implements SeriesStore {
         if (isFolder) childrenRepo.dropFolderEntry(key);
         childrenRepo.dropFileEntry(key);
     }
+    
+    @Override
+    public void createSeries(String key) {
+    	getOrMakeSeries(key);
+    }
+
+    @Override
+    public void deleteSeries(String key) {
+        unregisterKey(key);
+        deletePointsFromSeries(key);
+    }
+
 }


### PR DESCRIPTION
There is currently no createSeries option, though it can be faked by calling addPointsToSeries then deletePointsFromSeriesByPointKey.
Also deleteSeries and deletePointsFromSeries both delete the series - there's no way to drop all points and leave an empty series.