### PR TITLE
UNFILED: handle java 8 strict doclint.

### DIFF
--- a/Libs/build.gradle
+++ b/Libs/build.gradle
@@ -1,4 +1,3 @@
-
 buildscript {
   repositories {
     mavenCentral()
@@ -135,7 +134,6 @@ public static void addPath(Project project, String first, String second, String 
 }
 
 
-
 apply plugin: 'io.codearte.nexus-staging'
 
 
@@ -144,11 +142,21 @@ apply plugin: 'io.codearte.nexus-staging'
        javadoc {
           failOnError = false
        }
+
         task javadocJar(type: Jar) {
             classifier = 'javadoc'
             from javadoc
         }
 
+        if (JavaVersion.current().isJava8Compatible()) {
+           allprojects {
+               tasks.withType(Javadoc) {
+                  // disable the crazy super-strict doclint tool in Java 8
+                  options.addStringOption('Xdoclint:none', '-quiet')
+               }
+           }
+        }
+ 
         task sourcesJar(type: Jar) {
             classifier = 'sources'
             from sourceSets.main.allSource


### PR DESCRIPTION
based on this article http://blog.joda.org/2014/02/turning-off-doclint-in-jdk-8-javadoc.html

The build will output warnings.