### PR TITLE
RAP-4030 Some files contain Unicode strings.

### DIFF
--- a/Apps/build.gradle
+++ b/Apps/build.gradle
@@ -53,6 +53,8 @@ subprojects {
         include '**/*.txt', '**/*.xml', '**/*.properties', '**/*.proto'
     }
 
+    compileJava {options.encoding = "UTF-8" }
+    compileTestJava {options.encoding = "UTF-8" }
     compileJava {
         dependsOn copyProps
     }

--- a/Libs/RaptureCommon/src/test/java/rapture/util/RaptureURLCoderTest.java
+++ b/Libs/RaptureCommon/src/test/java/rapture/util/RaptureURLCoderTest.java
@@ -96,12 +96,14 @@ public class RaptureURLCoderTest {
     
     @Test
     public void testInternationalCharacters() {
+    	// If you don't see Cyrillic and Chinese characters your default character encoding is not UTF-8
         testNotEncoded("ДэвидТонг");
         testNotEncoded("大衛通");
     }
     
     @Test
     public void testEightBitSymbols() {
+    	// These are all single UTF-8 characters: Paragraph, GBP Currency, Section, +/-, JPY currency
         testReversible("¶");
         testReversible("£");
         testReversible("§");
@@ -111,6 +113,7 @@ public class RaptureURLCoderTest {
 
     @Test
     public void testEmoji() throws UnsupportedEncodingException {
+    	// This is a 'smiley face' emoji
         testReversible("😊");
     }
     
@@ -119,6 +122,7 @@ public class RaptureURLCoderTest {
      */
     @Test
     public void testSixteenBitSymbols() {
+    	// This is the Euro symbol
         testReversible("€");
     }
 

--- a/Libs/build.gradle
+++ b/Libs/build.gradle
@@ -62,6 +62,8 @@ subprojects {
         include '**/*.txt', '**/*.xml', '**/*.properties', '**/*.proto'
     }
 
+    compileJava {options.encoding = "UTF-8" }
+    compileTestJava {options.encoding = "UTF-8" }
     compileJava.dependsOn(copyProps)
 
     test {


### PR DESCRIPTION
Since windows is a crock^W^Wspecial it uses a different file encoding, and has to be asked nicely to quit fuW^Wuse UTF-8