### PR TITLE
ETN-237: update cass network mode (for single node cluster)

### DIFF
--- a/Apps/RaptureAPIServer/docker/docker-compose.yml
+++ b/Apps/RaptureAPIServer/docker/docker-compose.yml
@@ -35,6 +35,7 @@ services:
     depends_on:
       - rabbit
   cassandra:
+    network_mode: "host"
     image: 'incapture/cassandra:latest'
     ports:
       - '9160:9160'


### PR DESCRIPTION
If running docker locally with a single node cassandra cluster, sometimes cassandra refuses to restart if it doesn't hear any "gossip" from other nodes. This should fix that.