### PR TITLE
Fix pattern matching at last

### DIFF
--- a/Libs/WorkflowsCommonSteps/src/main/java/rapture/dp/invocable/ftp/steps/CheckFileExistsStep.java
+++ b/Libs/WorkflowsCommonSteps/src/main/java/rapture/dp/invocable/ftp/steps/CheckFileExistsStep.java
@@ -82,10 +82,12 @@ public class CheckFileExistsStep extends AbstractInvocable {
                     String target = e.getKey();
                     if (exists) {
                         List l = (List) request.getResult();
-                        if (l.size() > 1) {
-                            target = l.size() + " files matching " + e.getKey();
-                        } else {
-                            target = l.get(0).toString();
+                        if (l != null) {
+                            if (l.size() > 1) {
+                                target = l.size() + " files matching " + e.getKey();
+                            } else {
+                                target = l.get(0).toString();
+                            }
                         }
                     }
                     error.append(target).append(wasNotWas(exists)).append("found but").append(wasNotWas((Boolean) e.getValue())).append("expected ");

--- a/Libs/WorkflowsCommonSteps/src/main/java/rapture/ftp/common/FTPConnection.java
+++ b/Libs/WorkflowsCommonSteps/src/main/java/rapture/ftp/common/FTPConnection.java
@@ -54,7 +54,6 @@ public class FTPConnection implements Connection {
     FTPConnectionConfig config = null;
     boolean isLoggedIn = false;
     CallingContext context = ContextFactory.getAnonymousUser();
-    boolean error = false;
 
     public FTPConnection(FTPConnectionConfig config) {
         ftpClient = new FTPClient();

--- a/Libs/WorkflowsCommonSteps/src/main/java/rapture/ftp/common/FTPConnection.java
+++ b/Libs/WorkflowsCommonSteps/src/main/java/rapture/ftp/common/FTPConnection.java
@@ -22,10 +22,8 @@ import java.net.HttpURLConnection;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
@@ -56,6 +54,7 @@ public class FTPConnection implements Connection {
     FTPConnectionConfig config = null;
     boolean isLoggedIn = false;
     CallingContext context = ContextFactory.getAnonymousUser();
+    boolean error = false;
 
     public FTPConnection(FTPConnectionConfig config) {
         ftpClient = new FTPClient();
@@ -127,24 +126,15 @@ public class FTPConnection implements Connection {
                     exists = f.exists();
                 }
                 if (!exists && (f != null)) {
-                    int depth = 0;
                     do {
-                        depth++;
                         f = f.getParentFile();
                     } while (!f.exists());
 
-                    try {
-                        final String nam = name;
-                        List<Path> matches = Files.find(f.toPath(), depth, (path, basicFileAttributes) -> path.toFile().getAbsolutePath().matches(nam))
-                                .collect(Collectors.toList());
-                        exists = !matches.isEmpty();
-                        List<String> result = new ArrayList<>(matches.size());
-                        for (Path path : matches) {
-                            result.add(path.toString());
-                        }
-                        request.setResult(result);
-                    } catch (IOException e) {
-                    }
+                    PathMatcher matcher = new PathMatcher(name);
+                    Files.walkFileTree(f.toPath(), matcher);
+                    List<String> matches = matcher.getResults();
+                    request.setResult(matches);
+                    exists = !matches.isEmpty();
                 }
                 request.setLocal(true);
                 return exists;
@@ -159,7 +149,7 @@ public class FTPConnection implements Connection {
                 });
             }
         } catch (Exception e) {
-            log.debug(ExceptionToString.format(ExceptionToString.getRootCause(e)));
+            log.error(ExceptionToString.format(ExceptionToString.getRootCause(e)));
             return false;
         }
     }

--- a/Libs/WorkflowsCommonSteps/src/main/java/rapture/ftp/common/PathMatcher.java
+++ b/Libs/WorkflowsCommonSteps/src/main/java/rapture/ftp/common/PathMatcher.java
@@ -1,0 +1,46 @@
+package rapture.ftp.common;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
+
+class PathMatcher implements FileVisitor<Path> {
+
+    String pattern = null;
+    List<String> results;
+
+    public PathMatcher(String pattern) {
+        this.pattern = pattern;
+        results = new ArrayList<>();
+    }
+
+    @Override
+    public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+        return FileVisitResult.CONTINUE;
+    }
+
+    @Override
+    public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+        return FileVisitResult.CONTINUE;
+    }
+
+    @Override
+    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+        String path = file.toFile().getAbsolutePath();
+        if (path.matches(pattern)) results.add(path);
+        return FileVisitResult.CONTINUE;
+    }
+
+    @Override
+    public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
+        return FileVisitResult.CONTINUE;
+    }
+
+    public List<String> getResults() {
+        return results;
+    }
+}

--- a/Libs/WorkflowsCommonSteps/src/test/java/rapture/dp/invocable/ftp/steps/CheckFileExistsStepTest.java
+++ b/Libs/WorkflowsCommonSteps/src/test/java/rapture/dp/invocable/ftp/steps/CheckFileExistsStepTest.java
@@ -59,15 +59,85 @@ public class CheckFileExistsStepTest {
     }
 
     @Test
-    public void checkWildcardTest() {
+    public void checkWildcardTest1() {
         CallingContext ctx = ContextFactory.getAnonymousUser();
         String workerUri = "workorder://x/y#0";
         String workOrderUri = workerUri.substring(0, workerUri.length() - 2);
-        CheckFileExistsStep cfes = new CheckFileExistsStep(workerUri, "foo");
+        CheckFileExistsStep cfes = new CheckFileExistsStep(workerUri, "foo1");
         String filename = "/etc/aliase.";
         String expand = ExecutionContextUtil.evalTemplateECF(ctx, workerUri, filename, null);
-        Kernel.getDecision().setContextLiteral(ctx, workerUri, "EXIST_FILENAMES", JacksonUtil.jsonFromObject(ImmutableMap.of("/bin/c.", Boolean.TRUE,
-                "file://bin/m[a-z]{4}", Boolean.TRUE, "file://bin/y.*/z.*", Boolean.FALSE, "/b/w.*/f?/c", Boolean.FALSE)));
+        Kernel.getDecision().setContextLiteral(ctx, workerUri, "EXIST_FILENAMES", JacksonUtil.jsonFromObject(ImmutableMap.of("/bin/c.", Boolean.TRUE)));
         assertEquals(cfes.getNextTransition(), cfes.invoke(ctx));
+        assertEquals("", Kernel.getDecision().getContextValue(ctx, workerUri, "foo1Error"));
     }
+
+    @Test
+    public void checkWildcardTest2() {
+        CallingContext ctx = ContextFactory.getAnonymousUser();
+        String workerUri = "workorder://x/y#0";
+        String workOrderUri = workerUri.substring(0, workerUri.length() - 2);
+        CheckFileExistsStep cfes = new CheckFileExistsStep(workerUri, "foo2");
+        String filename = "/etc/aliase.";
+        String expand = ExecutionContextUtil.evalTemplateECF(ctx, workerUri, filename, null);
+        Kernel.getDecision().setContextLiteral(ctx, workerUri, "EXIST_FILENAMES", JacksonUtil.jsonFromObject(ImmutableMap.of("/bin/c.", Boolean.FALSE)));
+        assertEquals(cfes.getFailTransition(), cfes.invoke(ctx));
+        assertEquals("/bin/cp was found but was not expected ", Kernel.getDecision().getContextValue(ctx, workerUri, "foo2Error"));
+    }
+
+    @Test
+    public void checkWildcardTest3() {
+        CallingContext ctx = ContextFactory.getAnonymousUser();
+        String workerUri = "workorder://x/y#0";
+        String workOrderUri = workerUri.substring(0, workerUri.length() - 2);
+        CheckFileExistsStep cfes = new CheckFileExistsStep(workerUri, "foo3");
+        String filename = "/etc/aliase.";
+        String expand = ExecutionContextUtil.evalTemplateECF(ctx, workerUri, filename, null);
+        Kernel.getDecision().setContextLiteral(ctx, workerUri, "EXIST_FILENAMES", JacksonUtil.jsonFromObject(ImmutableMap.of("/bin/c.*", Boolean.TRUE)));
+        assertEquals(cfes.getNextTransition(), cfes.invoke(ctx));
+        assertEquals("", Kernel.getDecision().getContextValue(ctx, workerUri, "foo3Error"));
+    }
+
+    @Test
+    public void checkWildcardTest4() {
+        CallingContext ctx = ContextFactory.getAnonymousUser();
+        String workerUri = "workorder://x/y#0";
+        String workOrderUri = workerUri.substring(0, workerUri.length() - 2);
+        CheckFileExistsStep cfes = new CheckFileExistsStep(workerUri, "foo4");
+        String filename = "/etc/aliase.";
+        String expand = ExecutionContextUtil.evalTemplateECF(ctx, workerUri, filename, null);
+        Kernel.getDecision().setContextLiteral(ctx, workerUri, "EXIST_FILENAMES", JacksonUtil.jsonFromObject(ImmutableMap.of("/bin/c.*", Boolean.FALSE)));
+        assertEquals(cfes.getFailTransition(), cfes.invoke(ctx));
+        assertEquals("4 files matching /bin/c.* was found but was not expected ", Kernel.getDecision().getContextValue(ctx, workerUri, "foo4Error"));
+    }
+
+    @Test
+    public void checkWildcardTest5() {
+        CallingContext ctx = ContextFactory.getAnonymousUser();
+        String workerUri = "workorder://x/y#0";
+        String workOrderUri = workerUri.substring(0, workerUri.length() - 2);
+        CheckFileExistsStep cfes = new CheckFileExistsStep(workerUri, "foo5");
+        String filename = "/etc/aliase.";
+        String expand = ExecutionContextUtil.evalTemplateECF(ctx, workerUri, filename, null);
+        Kernel.getDecision().setContextLiteral(ctx, workerUri, "EXIST_FILENAMES",
+                JacksonUtil.jsonFromObject(ImmutableMap.of("/usr/sh.re/.{8}/I[a-z]+/Cocos", Boolean.TRUE)));
+        String trans = cfes.invoke(ctx);
+        assertEquals("", Kernel.getDecision().getContextValue(ctx, workerUri, "foo5Error"));
+        assertEquals(cfes.getNextTransition(), trans);
+    }
+
+    @Test
+    public void checkWildcardTest6() {
+        CallingContext ctx = ContextFactory.getAnonymousUser();
+        String workerUri = "workorder://x/y#0";
+        String workOrderUri = workerUri.substring(0, workerUri.length() - 2);
+        CheckFileExistsStep cfes = new CheckFileExistsStep(workerUri, "foo6");
+        String filename = "/etc/aliase.";
+        String expand = ExecutionContextUtil.evalTemplateECF(ctx, workerUri, filename, null);
+        Kernel.getDecision().setContextLiteral(ctx, workerUri, "EXIST_FILENAMES",
+                JacksonUtil.jsonFromObject(ImmutableMap.of("/usr/sh.re/.{8}/I[a-z]+/Cocos", Boolean.FALSE)));
+        String trans = cfes.invoke(ctx);
+        assertEquals("/usr/share/zoneinfo/Indian/Cocos was found but was not expected ", Kernel.getDecision().getContextValue(ctx, workerUri, "foo6Error"));
+        assertEquals(cfes.getFailTransition(), trans);
+    }
+
 }


### PR DESCRIPTION
The oh-so-clever Java 8 Files.find lambda function throws an exception if it encounters a directory that it doesn't have permission to enter. What's worse is that there's no way to catch or ignore that exception. 

Fortunately Java 7 had Files.walkFileTree which allows me to do the same thing albeit in a few more lines of code but at least it actually [EXPLETIVE DELETED] works.