### PR TITLE
Unfiled: Remove redundent appenders

### DIFF
--- a/Libs/RaptureCore/src/main/java/rapture/dp/WorkflowStepUtils.java
+++ b/Libs/RaptureCore/src/main/java/rapture/dp/WorkflowStepUtils.java
@@ -60,8 +60,9 @@ public class WorkflowStepUtils {
     public Logger getLogger() {
         if (log == null) {
             log = Logger.getLogger(workerUri + "/" + stepName);
-            Appender app = getAppender();
-            log.removeAppender(app);
+            Appender app = newAppender();
+            // Remove any previous appender with the same name
+            log.removeAppender(app.getName());
             log.addAppender(app);
         }
         return log;
@@ -97,7 +98,7 @@ public class WorkflowStepUtils {
         return InvocableUtils.getWorkflowAuditLog(worker.getAppStatusNameStack().get(0), worker.getWorkOrderURI(), stepName);
     }
 
-    Appender getAppender() {
+    Appender newAppender() {
         return new AuditAppender(getAuditLogUri());
     }
 

--- a/Libs/RaptureCore/src/test/java/rapture/dp/WorkflowStepUtilsTest.java
+++ b/Libs/RaptureCore/src/test/java/rapture/dp/WorkflowStepUtilsTest.java
@@ -73,7 +73,7 @@ public class WorkflowStepUtilsTest {
         }
 
         @Override
-        Appender getAppender() {
+        Appender newAppender() {
             return appender;
         }
 


### PR DESCRIPTION
log.removeAppender(app) only removes that specific instance of the appender.
Given that it's a new instance the call is pointless.
To remove any previous instance of the same appender it's necessary to pass the name.