### PR TITLE
chore: modernize dependency management

### DIFF
--- a/Apps/OperationTest/build.gradle
+++ b/Apps/OperationTest/build.gradle
@@ -1,7 +1,7 @@
 version = '3.0.0'
 
 dependencies {
-      compile "net.rapture:SelfPluginInstallerLib:$project.platformVersion"
+    implementation "net.rapture:SelfPluginInstallerLib:$project.platformVersion"
 }
 
 mainClassName = "rapture.plugin.app.SelfInstaller"
@@ -14,8 +14,8 @@ task fatJar(type: Jar) {
     }
     baseName = project.name
     from {
-        configurations.compile.collect {
-             it.isDirectory() ? it : zipTree(it) }
+        configurations.runtimeClasspath.collect {
+            it.isDirectory() ? it : zipTree(it) }
     } with jar
 }
 

--- a/Apps/PluginInstaller/build.gradle
+++ b/Apps/PluginInstaller/build.gradle
@@ -6,13 +6,13 @@ jar.manifest.attributes "Implementation-Title" : "Rapture PluginInstaller applic
 jar.manifest.attributes "Implementation-Version" : version
 
 dependencies {
-    compile 'jline:jline:2.7'
-    compile "net.rapture:PluginInstallerLib:$project.platformVersion"
-    compile "net.rapture:RaptureCore:$project.platformVersion"
-    compile "net.rapture:RaptureAddinCore:$project.platformVersion"
-    compile "net.rapture:MongoDb:$project.platformVersion"
-    compile "net.rapture:RabbitMQ:$project.platformVersion"
-    compile "net.rapture:Cassandra:$project.platformVersion"
+    implementation libs.jline
+    implementation "net.rapture:PluginInstallerLib:$project.platformVersion"
+    implementation "net.rapture:RaptureCore:$project.platformVersion"
+    implementation "net.rapture:RaptureAddinCore:$project.platformVersion"
+    implementation "net.rapture:MongoDb:$project.platformVersion"
+    implementation "net.rapture:RabbitMQ:$project.platformVersion"
+    implementation "net.rapture:Cassandra:$project.platformVersion"
 }
 
 mainClassName = "rapture.plugin.install.PluginShell"

--- a/Apps/RaptureAPIServer/build.gradle
+++ b/Apps/RaptureAPIServer/build.gradle
@@ -29,28 +29,28 @@ startScripts {
 }
 
 dependencies {
-    compile "net.rapture:WorkflowsCore:$project.platformVersion"
-    compile "net.rapture:RaptureCore:$project.platformVersion"
-    compile "net.rapture:RaptureAddinCore:$project.platformVersion"
-    compile "net.rapture:MongoDb:$project.platformVersion"
-    compile "net.rapture:GoogleCloud:$project.platformVersion"
-    compile "net.rapture:RabbitMQ:$project.platformVersion"
-    compile "net.rapture:ElasticSearch:$project.platformVersion"
-    compile "net.rapture:Postgres:$project.platformVersion"
-    compile "net.rapture:ZooKeeper:$project.platformVersion"
-    compile("net.rapture:Cassandra:$project.platformVersion") {
+    implementation "net.rapture:WorkflowsCore:$project.platformVersion"
+    implementation "net.rapture:RaptureCore:$project.platformVersion"
+    implementation "net.rapture:RaptureAddinCore:$project.platformVersion"
+    implementation "net.rapture:MongoDb:$project.platformVersion"
+    implementation "net.rapture:GoogleCloud:$project.platformVersion"
+    implementation "net.rapture:RabbitMQ:$project.platformVersion"
+    implementation "net.rapture:ElasticSearch:$project.platformVersion"
+    implementation "net.rapture:Postgres:$project.platformVersion"
+    implementation "net.rapture:ZooKeeper:$project.platformVersion"
+    implementation("net.rapture:Cassandra:$project.platformVersion") {
        exclude module: 'servlet-api'
     }
-    compile "net.rapture:RaptureWebServlet:$project.platformVersion"
-    compile 'org.apache.tomcat.embed:tomcat-embed-logging-juli:8.0.20'
-    compile 'org.apache.tomcat.embed:tomcat-embed-core:8.0.20'
-    compile 'org.apache.tomcat.embed:tomcat-embed-jasper:8.0.20'
-    compile 'org.apache.tomcat:tomcat-api:8.0.20'
-    compile 'org.apache.tomcat:tomcat-jasper:8.0.20'
-    compile 'org.apache.tomcat:tomcat-jasper-el:8.0.20'
-    compile 'org.apache.tomcat:tomcat-jsp-api:8.0.20'
-    compile 'org.apache.tomcat:tomcat-websocket:8.0.20'
-    compile "javax.servlet:javax.servlet-api:3.1.0"
+    implementation "net.rapture:RaptureWebServlet:$project.platformVersion"
+    implementation libs.tomcatEmbedLoggingJuli
+    implementation libs.tomcatEmbedCore
+    implementation libs.tomcatEmbedJasper
+    implementation libs.tomcatApi
+    implementation libs.tomcatJasper
+    implementation libs.tomcatJasperEl
+    implementation libs.tomcatJspApi
+    implementation libs.tomcatWebsocket
+    implementation libs.servletApi
 }
 
 mainClassName = "rapture.server.RaptureAPIServer"

--- a/Apps/RaptureIntTests/build.gradle
+++ b/Apps/RaptureIntTests/build.gradle
@@ -8,19 +8,19 @@ mainClassName = "rapture.test.java"
 def nosetestsCmd = System.properties['nosetests'] ?: "nosetests"
 
 dependencies {
-    compile "net.rapture:WorkflowsCore:$project.platformVersion"
-    compile "net.rapture:RaptureCore:$project.platformVersion"
-    compile "net.rapture:RaptureAddinCore:$project.platformVersion"
-    compile "net.rapture:MongoDb:$project.platformVersion"
-    compile "net.rapture:GoogleCloud:$project.platformVersion"
-    compile "net.rapture:RabbitMQ:$project.platformVersion"
-    compile "net.rapture:PluginInstallerLib:$project.platformVersion"
-    compile("net.rapture:Cassandra:$project.platformVersion") {
+    implementation "net.rapture:WorkflowsCore:$project.platformVersion"
+    implementation "net.rapture:RaptureCore:$project.platformVersion"
+    implementation "net.rapture:RaptureAddinCore:$project.platformVersion"
+    implementation "net.rapture:MongoDb:$project.platformVersion"
+    implementation "net.rapture:GoogleCloud:$project.platformVersion"
+    implementation "net.rapture:RabbitMQ:$project.platformVersion"
+    implementation "net.rapture:PluginInstallerLib:$project.platformVersion"
+    implementation("net.rapture:Cassandra:$project.platformVersion") {
        exclude module: 'servlet-api'
     }
-    compile 'org.testng:testng:6.9.10'
-    compile 'javax.mail:mail:1.4.5'
-    compile 'com.github.fge:json-patch:1.9'
+    testImplementation libs.testng
+    testImplementation libs.mail
+    testImplementation libs.jsonPatch
 }
 
 

--- a/Apps/RaptureWebServer/build.gradle
+++ b/Apps/RaptureWebServer/build.gradle
@@ -29,24 +29,24 @@ startScripts {
 }
 
 dependencies {
-    compile group: 'javax.servlet', name: 'javax.servlet-api', version: '3.1.0'
-    compile("net.rapture:WorkflowsCore:$project.platformVersion") { exclude module: 'servlet-api' }
-    compile("net.rapture:RaptureCore:$project.platformVersion") { exclude module: 'servlet-api' }
-    compile("net.rapture:RaptureAddinCore:$project.platformVersion") { exclude module: 'servlet-api' }
-    compile("net.rapture:MongoDb:$project.platformVersion") { exclude module: 'servlet-api' }
-    compile("net.rapture:RabbitMQ:$project.platformVersion") { exclude module: 'servlet-api' }
-    compile("net.rapture:ElasticSearch:$project.platformVersion") { exclude module: 'servlet-api' }
-    compile("net.rapture:Postgres:$project.platformVersion") { exclude module: 'servlet-api' }
-    compile("net.rapture:Cassandra:$project.platformVersion") { exclude module: 'servlet-api' }
-    compile("net.rapture:RaptureWebServlet:$project.platformVersion") { exclude module: 'servlet-api' }
-	compile 'org.apache.tomcat.embed:tomcat-embed-logging-juli:8.0.20'
-	compile 'org.apache.tomcat.embed:tomcat-embed-core:8.0.20'
-	compile 'org.apache.tomcat.embed:tomcat-embed-jasper:8.0.20'
-	compile 'org.apache.tomcat:tomcat-api:8.0.20'
-	compile 'org.apache.tomcat:tomcat-jasper:8.0.20'
-	compile 'org.apache.tomcat:tomcat-jasper-el:8.0.20'
-	compile 'org.apache.tomcat:tomcat-jsp-api:8.0.20'
-	compile 'org.apache.tomcat:tomcat-websocket:8.0.20'
+    implementation libs.servletApi
+    implementation("net.rapture:WorkflowsCore:$project.platformVersion") { exclude module: 'servlet-api' }
+    implementation("net.rapture:RaptureCore:$project.platformVersion") { exclude module: 'servlet-api' }
+    implementation("net.rapture:RaptureAddinCore:$project.platformVersion") { exclude module: 'servlet-api' }
+    implementation("net.rapture:MongoDb:$project.platformVersion") { exclude module: 'servlet-api' }
+    implementation("net.rapture:RabbitMQ:$project.platformVersion") { exclude module: 'servlet-api' }
+    implementation("net.rapture:ElasticSearch:$project.platformVersion") { exclude module: 'servlet-api' }
+    implementation("net.rapture:Postgres:$project.platformVersion") { exclude module: 'servlet-api' }
+    implementation("net.rapture:Cassandra:$project.platformVersion") { exclude module: 'servlet-api' }
+    implementation("net.rapture:RaptureWebServlet:$project.platformVersion") { exclude module: 'servlet-api' }
+    implementation libs.tomcatEmbedLoggingJuli
+    implementation libs.tomcatEmbedCore
+    implementation libs.tomcatEmbedJasper
+    implementation libs.tomcatApi
+    implementation libs.tomcatJasper
+    implementation libs.tomcatJasperEl
+    implementation libs.tomcatJspApi
+    implementation libs.tomcatWebsocket
 }
 
 mainClassName = "rapture.server.RaptureWebServer"

--- a/Apps/ReflexRunner/build.gradle
+++ b/Apps/ReflexRunner/build.gradle
@@ -6,7 +6,7 @@ jar.manifest.attributes "Implementation-Title" : "Rapture ReflexRunner applicati
 jar.manifest.attributes "Implementation-Version" : version
 
 dependencies {
-    compile 'jline:jline:2.7'
+    implementation libs.jline
 }
 
 mainClassName = "reflex.app.Runner"

--- a/Apps/RestServer/build.gradle
+++ b/Apps/RestServer/build.gradle
@@ -4,16 +4,16 @@ jar.manifest.attributes "Implementation-Title" : "RestServer application"
 jar.manifest.attributes "Implementation-Version" : version
 
 dependencies {
-  compile "net.rapture:RaptureAPI:$project.platformVersion"
-  compile "net.rapture:RaptureCore:$project.platformVersion"
-  compile "net.rapture:RaptureAppConfig:$project.platformVersion"
-  compile "net.rapture:MongoDb:$project.platformVersion"
-  compile "net.rapture:RabbitMQ:$project.platformVersion"
-  compile "net.rapture:ElasticSearch:$project.platformVersion"
-  compile "net.rapture:Postgres:$project.platformVersion"
-  compile "net.rapture:Cassandra:$project.platformVersion"
-  compile "com.sparkjava:spark-core:2.5.3"
-  compile 'com.mashape.unirest:unirest-java:1.4.9'
+    implementation "net.rapture:RaptureAPI:$project.platformVersion"
+    implementation "net.rapture:RaptureCore:$project.platformVersion"
+    implementation "net.rapture:RaptureAppConfig:$project.platformVersion"
+    implementation "net.rapture:MongoDb:$project.platformVersion"
+    implementation "net.rapture:RabbitMQ:$project.platformVersion"
+    implementation "net.rapture:ElasticSearch:$project.platformVersion"
+    implementation "net.rapture:Postgres:$project.platformVersion"
+    implementation "net.rapture:Cassandra:$project.platformVersion"
+    implementation libs.sparkCore
+    implementation libs.unirest
 }
 
 startScripts {

--- a/Apps/ScheduleServer/build.gradle
+++ b/Apps/ScheduleServer/build.gradle
@@ -6,11 +6,11 @@ jar.manifest.attributes "Implementation-Title" : "Rapture ScheduleServer applica
 jar.manifest.attributes "Implementation-Version" : version
 
 dependencies {
-     compile "net.rapture:MongoDb:$project.platformVersion"
-     compile "net.rapture:RabbitMQ:$project.platformVersion"
-	 compile "net.rapture:RaptureCore:$project.platformVersion"
-	 compile "net.rapture:RaptureAddinCore:$project.platformVersion"
-     compile 'jline:jline:2.7'
+    implementation "net.rapture:MongoDb:$project.platformVersion"
+    implementation "net.rapture:RabbitMQ:$project.platformVersion"
+    implementation "net.rapture:RaptureCore:$project.platformVersion"
+    implementation "net.rapture:RaptureAddinCore:$project.platformVersion"
+    implementation libs.jline
 }
 
 mainClassName = "rapture.server.ScheduleServer"

--- a/Apps/WatchServer/build.gradle
+++ b/Apps/WatchServer/build.gradle
@@ -23,14 +23,14 @@ startScripts {
 }
 
 dependencies {
-     compile 'org.apache.commons:commons-vfs2:2.1'
-     compile 'commons-net:commons-net:3.5'
-     compile 'commons-validator:commons-validator:1.5.1'
-     compile "net.rapture:MongoDb:$project.platformVersion"
-     compile "net.rapture:RabbitMQ:$project.platformVersion"
-     compile "net.rapture:RaptureCore:$project.platformVersion"
-     compile "net.rapture:RaptureAddinCore:$project.platformVersion"
-     compile 'jline:jline:2.7'
+    implementation libs.commonsVfs
+    implementation libs.commonsNet
+    implementation libs.commonsValidator
+    implementation "net.rapture:MongoDb:$project.platformVersion"
+    implementation "net.rapture:RabbitMQ:$project.platformVersion"
+    implementation "net.rapture:RaptureCore:$project.platformVersion"
+    implementation "net.rapture:RaptureAddinCore:$project.platformVersion"
+    implementation libs.jline
 }
 
 mainClassName = "watchserver.server.WatchServer"

--- a/Apps/WatchServerPlugin/build.gradle
+++ b/Apps/WatchServerPlugin/build.gradle
@@ -5,12 +5,12 @@ ext {
 }
 
 dependencies {
-  compile "net.rapture:RaptureCore:$project.platformVersion"
-  compile "net.rapture:SelfPluginInstallerLib:$project.platformVersion"
-  compile 'commons-net:commons-net:3.5'
-  compile 'org.apache.poi:poi:3.15'
-  compile 'org.apache.poi:poi-ooxml:3.15'
-  compile 'org.apache.poi:poi-ooxml-schemas:3.15'
+    implementation "net.rapture:RaptureCore:$project.platformVersion"
+    implementation "net.rapture:SelfPluginInstallerLib:$project.platformVersion"
+    implementation libs.commonsNet
+    implementation libs.poi
+    implementation libs.poiOoxml
+    implementation libs.poiOoxmlSchemas
 }
 
 mainClassName = "rapture.plugin.app.SelfInstaller"

--- a/Apps/build.gradle
+++ b/Apps/build.gradle
@@ -45,17 +45,12 @@ subprojects {
     }
 
     repositories {
-      mavenLocal()
-      mavenCentral()
-      jcenter()
-      maven {
-        url "https://oss.sonatype.org/content/repositories/releases/"
-      }
-      }
-
-    def loggingVersion = '1.6.1'
-    def httpVersion = '4.2.2'
-    def jacksonVersion = '1.9.2'
+        mavenLocal()
+        mavenCentral()
+        maven {
+            url "https://oss.sonatype.org/content/repositories/releases/"
+        }
+    }
 
     task copyProps(type:Copy) {
         from 'src/main/java'
@@ -138,19 +133,19 @@ subprojects {
     }
 
     dependencies {
-        compile "net.rapture:RaptureAppConfig:$project.platformVersion"
-        compile "net.rapture:RaptureAPI:$project.platformVersion"
-        compile "net.rapture:Reflex:$project.platformVersion"
-        compile 'log4j:log4j:1.2.14'
-        compile "org.slf4j:jcl-over-slf4j:$loggingVersion"
-        compile "org.slf4j:slf4j-api:$loggingVersion"
-        compile "org.slf4j:slf4j-log4j12:$loggingVersion"
-        testCompile 'junit:junit:4.10'
-        testCompile 'com.googlecode.catch-exception:catch-exception:1.0.4'
-        testCompile 'org.objenesis:objenesis:2.0'
-        testCompile 'org.powermock:powermock-module-junit4:1.5.1'
-        testCompile 'org.powermock:powermock-api-easymock:1.5.1'
-        testCompile 'org.easymock:easymock:3.2'
+        implementation "net.rapture:RaptureAppConfig:$project.platformVersion"
+        implementation "net.rapture:RaptureAPI:$project.platformVersion"
+        implementation "net.rapture:Reflex:$project.platformVersion"
+        implementation libs.log4j
+        implementation libs.slf4jJclOver
+        implementation libs.slf4jApi
+        implementation libs.slf4jLog4j12
+        testImplementation libs.junit4
+        testImplementation libs.catchException
+        testImplementation libs.objenesis
+        testImplementation libs.powermockModuleJUnit4
+        testImplementation libs.powermockApiEasyMock
+        testImplementation libs.easymock
     }
 
     startScripts {

--- a/Apps/gradle/libs.versions.toml
+++ b/Apps/gradle/libs.versions.toml
@@ -1,0 +1,54 @@
+[versions]
+log4j = "1.2.14"
+slf4j = "1.6.1"
+junit4 = "4.10"
+catchException = "1.0.4"
+objenesis = "2.0"
+powermock = "1.5.1"
+easymock = "3.2"
+jline = "2.7"
+commonsVfs = "2.1"
+commonsNet = "3.5"
+commonsValidator = "1.5.1"
+tomcat = "8.0.20"
+servletApi = "3.1.0"
+spark = "2.5.3"
+unirest = "1.4.9"
+testng = "6.9.10"
+mail = "1.4.5"
+jsonPatch = "1.9"
+poi = "3.15"
+poiSchemas = "3.15"
+
+[libraries]
+log4j = { module = "log4j:log4j", version.ref = "log4j" }
+slf4jJclOver = { module = "org.slf4j:jcl-over-slf4j", version.ref = "slf4j" }
+slf4jApi = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
+slf4jLog4j12 = { module = "org.slf4j:slf4j-log4j12", version.ref = "slf4j" }
+junit4 = { module = "junit:junit", version.ref = "junit4" }
+catchException = { module = "com.googlecode.catch-exception:catch-exception", version.ref = "catchException" }
+objenesis = { module = "org.objenesis:objenesis", version.ref = "objenesis" }
+powermockModuleJUnit4 = { module = "org.powermock:powermock-module-junit4", version.ref = "powermock" }
+powermockApiEasyMock = { module = "org.powermock:powermock-api-easymock", version.ref = "powermock" }
+easymock = { module = "org.easymock:easymock", version.ref = "easymock" }
+jline = { module = "jline:jline", version.ref = "jline" }
+commonsVfs = { module = "org.apache.commons:commons-vfs2", version.ref = "commonsVfs" }
+commonsNet = { module = "commons-net:commons-net", version.ref = "commonsNet" }
+commonsValidator = { module = "commons-validator:commons-validator", version.ref = "commonsValidator" }
+tomcatEmbedLoggingJuli = { module = "org.apache.tomcat.embed:tomcat-embed-logging-juli", version.ref = "tomcat" }
+tomcatEmbedCore = { module = "org.apache.tomcat.embed:tomcat-embed-core", version.ref = "tomcat" }
+tomcatEmbedJasper = { module = "org.apache.tomcat.embed:tomcat-embed-jasper", version.ref = "tomcat" }
+tomcatApi = { module = "org.apache.tomcat:tomcat-api", version.ref = "tomcat" }
+tomcatJasper = { module = "org.apache.tomcat:tomcat-jasper", version.ref = "tomcat" }
+tomcatJasperEl = { module = "org.apache.tomcat:tomcat-jasper-el", version.ref = "tomcat" }
+tomcatJspApi = { module = "org.apache.tomcat:tomcat-jsp-api", version.ref = "tomcat" }
+tomcatWebsocket = { module = "org.apache.tomcat:tomcat-websocket", version.ref = "tomcat" }
+servletApi = { module = "javax.servlet:javax.servlet-api", version.ref = "servletApi" }
+sparkCore = { module = "com.sparkjava:spark-core", version.ref = "spark" }
+unirest = { module = "com.mashape.unirest:unirest-java", version.ref = "unirest" }
+testng = { module = "org.testng:testng", version.ref = "testng" }
+mail = { module = "javax.mail:mail", version.ref = "mail" }
+jsonPatch = { module = "com.github.fge:json-patch", version.ref = "jsonPatch" }
+poi = { module = "org.apache.poi:poi", version.ref = "poi" }
+poiOoxml = { module = "org.apache.poi:poi-ooxml", version.ref = "poi" }
+poiOoxmlSchemas = { module = "org.apache.poi:poi-ooxml-schemas", version.ref = "poiSchemas" }


### PR DESCRIPTION
## Summary
- introduce a Gradle version catalog to centralize third-party dependency versions for Apps modules
- replace deprecated compile/testCompile configurations with implementation/testImplementation across application projects and update fat jar packaging to use runtimeClasspath
- drop the legacy jcenter repository reference from the shared subproject configuration

## Testing
- ./gradlew help *(fails: gradle wrapper jar missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e56a5ccc8c8320b909e524ac400c79