### PR TITLE
Add Dependabot configuration for automated updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+      include: "scope"


### PR DESCRIPTION
## Summary
- add a Dependabot configuration to automate Gradle and GitHub Actions updates
- schedule weekly runs with scoped commit message prefixes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e572a156f48320bdcc7667eed45872